### PR TITLE
Refine EV layout and filter incomplete market rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -358,59 +358,117 @@ footer {
 
 .ev-game {
   border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 12px;
-  padding: 16px;
-  margin-bottom: 16px;
-  background: rgba(148, 163, 184, 0.08);
+  border-radius: 16px;
+  padding: 18px 18px 20px 18px;
+  margin-bottom: 18px;
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.85), rgba(15, 23, 42, 0.85));
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.15);
 }
 
-.ev-game h3 {
-  margin: 0 0 12px 0;
+.ev-game-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.ev-matchup {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.ev-team {
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.ev-team.ev-home {
+  color: var(--accent);
+}
+
+.ev-vs {
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  color: var(--subtle);
+  letter-spacing: 0.12em;
+}
+
+.ev-game-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.85rem;
+}
+
+.ev-meta-item {
+  background: rgba(148, 163, 184, 0.12);
+  border-radius: 999px;
+  padding: 4px 12px;
+  color: var(--subtle);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ev-meta-item.ev-date {
+  background: rgba(34, 211, 238, 0.14);
+  color: var(--accent);
+}
+
+.ev-meta-item strong {
+  color: var(--text);
 }
 
 .ev-board {
-  margin-top: 12px;
+  margin-top: 18px;
 }
 
 .ev-board-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
 }
 
 .ev-column {
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 12px;
-  padding: 14px;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 14px;
+  padding: 16px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 14px;
 }
 
 .ev-column-title {
   font-weight: 600;
   color: var(--subtle);
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  font-size: 0.8rem;
 }
 
 .ev-card {
-  background: rgba(15, 23, 42, 0.9);
-  border: 1px solid rgba(148, 163, 184, 0.15);
-  border-radius: 10px;
-  padding: 12px;
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 12px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.1);
 }
 
 .ev-card-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 8px;
+  gap: 10px;
 }
 
 .ev-card-team {
@@ -420,21 +478,38 @@ footer {
 }
 
 .ev-tag {
-  background: rgba(34, 211, 238, 0.15);
+  background: rgba(34, 211, 238, 0.18);
   color: var(--accent);
   border-radius: 999px;
-  padding: 2px 10px;
+  padding: 3px 12px;
   font-size: 0.75rem;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.04em;
 }
 
-.ev-consensus {
+.ev-card-details {
+  display: grid;
+  gap: 6px;
+}
+
+.ev-detail {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  background: rgba(148, 163, 184, 0.08);
+  border-radius: 8px;
   font-size: 0.85rem;
-  color: var(--subtle);
 }
 
-.ev-consensus strong {
+.ev-detail-label {
+  color: var(--subtle);
+  font-weight: 500;
+}
+
+.ev-detail-value {
   color: var(--text);
+  font-variant-numeric: tabular-nums;
 }
 
 .ev-inputs {
@@ -475,18 +550,27 @@ footer {
   font-size: 0.85rem;
   color: var(--subtle);
   display: grid;
-  gap: 2px;
-}
-
-.ev-results span {
-  display: flex;
-  justify-content: space-between;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 8px;
 }
 
-.ev-results span strong {
+.ev-metric {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 10px;
+  background: rgba(34, 211, 238, 0.08);
+  border-radius: 8px;
+}
+
+.ev-metric-label {
+  color: var(--subtle);
   font-weight: 500;
+}
+
+.ev-metric-value {
   color: var(--text);
+  font-variant-numeric: tabular-nums;
 }
 
 .custom-form {
@@ -523,6 +607,14 @@ footer {
 
   .ev-board-grid {
     grid-template-columns: 1fr;
+  }
+
+  .ev-results {
+    grid-template-columns: 1fr;
+  }
+
+  .ev-game-header {
+    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
## Summary
- restyle the EV Calculator with structured matchup headers, detail rows, and metric chips for improved readability
- introduce helpers for rendering EV metrics and details while updating card markup to use the new styling
- hide upcoming games that still lack sportsbook market data so the table only shows complete rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d35323784083219082c4dca6d8f8d6